### PR TITLE
Renamed environment to match environment name across platforms

### DIFF
--- a/environmentWin.yml
+++ b/environmentWin.yml
@@ -1,4 +1,4 @@
-name: MumotEnvWin
+name: MumotEnv
 channels:
 - conda-forge
 - defaults


### PR DESCRIPTION
Renamed environment from `MumotEnvWin` to `MuMotEnv`