### PR TITLE
mybinder.org compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,30 @@ The visualisation of particular representations of models requires that you have
 Hyperlinked tables of contents can be userful when viewing longer Notebooks such as the [MuMoT User Manual](docs/MuMoTuserManual.ipynb).
 Tables of contents can be displayed if you enable the **TOC2** Jupyter Extension as follows:
 
- 1. If using conda:
+ 1. Ensure the `jupyter_contrib_nbextensions` package is installed. 
+    This is "a collection of extensions that add functionality to the Jupyter notebook".
+    If you installed MuMoT using **conda** and an enclosed `environment.yml` file then you can **skip this step**.
+    If you  installed MuMoT into a *virtualenv* using **pip** then you need to 
+    ensure that virtualenv is activated then **run**:
+ 
+    ```sh
+    pip install jupyter_contrib_nbextensions
+    ```
+
+1.  Enable `jupyter_contrib_nbextensions`:
+
+    ```sh
+    jupyter contrib nbextension install --sys-prefix
+    ```
+
+1.  Enable the TOC2 ('table of contents') extension that is provided by `jupyter_contrib_nbextensions`:
+
+    ```sh
+    jupyter nbextension enable toc2/main
+    ```
+
+ 1. Enable a graphical interface for enabling/disabling TOC2 and other Jupyter extensions.
+    If using conda:
 
     ```sh
     conda install -c conda-forge jupyter_nbextensions_configurator
@@ -111,17 +134,14 @@ Tables of contents can be displayed if you enable the **TOC2** Jupyter Extension
 
     ```sh
     pip install jupyter_nbextensions_configurator  # AND 
-    jupyter nbextensions_configurator enable --user
+    jupyter nbextensions_configurator enable --sys-prefix
     ```
-    
- 1. Start a Jupyter Notebook server with
 
-    ```sh
-    jupyter notebook
-    ```
-    
- 1. Click the *nbextensions* tab and enable the *TOC2* extension.
- 1. Subsequently, within any Notebook you can toggle the table of contents by clicking on the appropriate button in the toolbar.
+The next time you start Jupyter from your conda environment or virtualenv then open a Notebook 
+you should see a table of contents displayed down the left-hand-side of the Notebook.
+
+If you subsequently want to disable the TOC2 extension and/or enable other Notebook extensions then 
+click '*Nbextensions*' in the Jupyter file browser tab.
 
 ## Starting using MuMoT
 

--- a/README.md
+++ b/README.md
@@ -239,4 +239,4 @@ MuMoT developed with funds from the European Research Council (ERC) under the Eu
 
 * [mumot/process_latex/](mumot/process_latex): LaTeX parser; taken from [latex2sympy](https://github.com/augustt198/latex2sympy) project and updated for Python 3) ((C) latex2sympy, under the MIT license)
 * [mumot/gen](mumot/gen): includes submodules used by MuMoT
-* [mumot/__init__.py](mumot/__init__.py): contains functions (C) 2012 Free Software Foundation, under the MIT Licence
+* [mumot/\_\_init\_\_.py](mumot/__init__.py): contains functions (C) 2012 Free Software Foundation, under the MIT Licence

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.com/DiODeProject/MuMoT.svg?token=6zhMFY3Y4Ems6GzwEDLn&branch=master)](https://travis-ci.com/DiODeProject/MuMoT)
 
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/DiODeProject/MuMoT/master?filepath=docs%2FMuMoTuserManual.ipynb)
+
 ## Introduction / overview
 
 TODO

--- a/apt.txt
+++ b/apt.txt
@@ -1,0 +1,8 @@
+texlive-latex-base
+texlive-latex-recommended
+texlive-science
+texlive-latex-extra
+texlive-fonts-recommended
+dvipng
+ghostscript
+graphviz

--- a/environment.yml
+++ b/environment.yml
@@ -1,97 +1,116 @@
-name: MumotEnv
+name: testing123
 channels:
-- conda-forge
-- defaults
+  - defaults
+  - anaconda-fusion
+  - conda-forge
 dependencies:
-- bleach=2.0.0=py35_0
-- entrypoints=0.2.3=py35_1
-- html5lib=1.0.1=py_0
-- ipython=6.2.1=py35_1
-- ipython_genutils=0.2.0=py35_0
-- ipywidgets=7.0.5=py35_0
-- jedi=0.11.1=py35_0
-- jinja2=2.10=py35_0
-- jsonschema=2.6.0=py35_0
-- jupyter_client=5.2.2=py35_0
-- jupyter_contrib_core=0.3.3=py35_1
-- jupyter_contrib_nbextensions=0.5.0=py35_0
-- jupyter_core=4.4.0=py_0
-- jupyter_highlight_selected_word=0.1.1=py35_0
-- jupyter_latex_envs=1.4.4=py35_0
-- jupyter_nbextensions_configurator=0.4.0=py35_0
-- libiconv=1.15=0
-- libsodium=1.0.15=1
-- libxslt=1.1.29=4
-- lxml=4.2.1=py35_0
-- markupsafe=1.0=py35_0
-- mistune=0.8.3=py_0
-- nbconvert=5.3.1=py_1
-- nbformat=4.4.0=py35_0
-- notebook=5.4.0=py35_0
-- pandoc=2.1.1=0
-- pandocfilters=1.4.1=py35_0
-- parso=0.1.1=py_0
-- pexpect=4.3.1=py35_0
-- pickleshare=0.7.4=py35_0
-- prompt_toolkit=1.0.15=py35_0
-- ptyprocess=0.5.2=py35_0
-- pygments=2.2.0=py35_0
-- pyyaml=3.12=py35_1
-- pyzmq=16.0.2=py35_3
-- send2trash=1.4.2=py_0
-- simplegeneric=0.8.1=py35_0
-- terminado=0.8.1=py35_0
-- testpath=0.3.1=py35_0
-- tornado=4.5.3=py35_0
-- traitlets=4.3.2=py35_0
-- wcwidth=0.1.7=py35_0
-- webencodings=0.5=py35_0
-- widgetsnbextension=3.1.3=py35_0
-- yaml=0.1.7=0
-- zeromq=4.2.1=1
-- certifi=2016.2.28=py35_0
-- cycler=0.10.0=py35_0
-- decorator=4.1.2=py35_0
-- freetype=2.5.5=2
-- icu=54.1=0
-- ipykernel=4.6.1=py35_0
-- libpng=1.6.30=1
-- libxml2=2.9.4=0
-- matplotlib=2.0.2=np113py35_0
-- mkl=2017.0.3=0
-- mpmath=0.19=py35_1
-- networkx=1.11=py35_0
-- numpy=1.13.1=py35_0
-- openssl=1.0.2l=0
-- pip=9.0.1=py35_1
-- pyparsing=2.2.0=py35_0
-- pyqt=5.6.0=py35_2
-- python=3.5.4=0
-- python-dateutil=2.6.1=py35_0
-- pytz=2017.2=py35_0
-- qt=5.6.2=2
-- readline=6.2=2
-- scipy=0.19.1=np113py35_0
-- setuptools=36.4.0=py35_1
-- sip=4.18=py35_0
-- six=1.10.0=py35_0
-- sqlite=3.13.0=0
-- sympy=1.1.1=py35_0
-- tk=8.5.18=0
-- wheel=0.29.0=py35_0
-- xz=5.2.3=0
-- zlib=1.2.11=0
-- pip:
-  - antlr4-python3-runtime==4.5.3
-  - graphviz==0.8.2
-  - ipython-genutils==0.2.0
-  - jupyter-client==5.2.2
-  - jupyter-contrib-core==0.3.3
-  - jupyter-contrib-nbextensions==0.5.0
-  - jupyter-core==4.4.0
-  - jupyter-highlight-selected-word==0.1.1
-  - jupyter-latex-envs==1.4.4
-  - jupyter-nbextensions-configurator==0.4.0
-  - prompt-toolkit==1.0.15
-  - pydstool==0.90.2
+  - bleach=2.0.0=py35_0
+  - ca-certificates=2018.4.16=0
+  - certifi=2016.2.28=py35_0
+  - cycler=0.10.0=py35_0
+  - dbus=1.13.0=h3a4f0e9_0
+  - decorator=4.1.2=py35_0
+  - entrypoints=0.2.3=py35_1
+  - expat=2.2.5=hfc679d8_1
+  - fastcache=1.0.2=py35h470a237_1
+  - gettext=0.19.8.1=0
+  - glib=2.53.5=1
+  - gmp=6.1.2=hfc679d8_0
+  - gmpy2=2.0.8=py35_0
+  - gst-plugins-base=1.8.0=0
+  - gstreamer=1.8.0=1
+  - html5lib=1.0.1=py_0
+  - ipykernel=4.6.1=py35_0
+  - ipython=6.2.1=py35_1
+  - ipython_genutils=0.2.0=py35_0
+  - ipywidgets=7.0.5=py35_0
+  - jedi=0.11.1=py35_0
+  - jinja2=2.10=py35_0
+  - jpeg=9c=h470a237_0
+  - jsonschema=2.6.0=py35_0
+  - jupyter_client=5.2.2=py35_0
+  - jupyter_contrib_core=0.3.3=py35_1
+  - jupyter_contrib_nbextensions=0.5.0=py35_0
+  - jupyter_core=4.4.0=py_0
+  - jupyter_highlight_selected_word=0.1.1=py35_0
+  - jupyter_latex_envs=1.4.4=py35_0
+  - jupyter_nbextensions_configurator=0.4.0=py35_0
+  - libffi=3.2.1=3
+  - libiconv=1.14=4
+  - libsodium=1.0.15=1
+  - libxcb=1.13=h470a237_2
+  - libxslt=1.1.29=4
+  - lxml=4.2.1=py35_0
+  - markupsafe=1.0=py35_0
+  - mistune=0.8.3=py_0
+  - mpc=1.1.0=hb705a9b_6
+  - mpfr=4.0.1=h16a7912_0
+  - mpmath=0.19=py35_1
+  - nbconvert=5.3.1=py_1
+  - nbformat=4.4.0=py35_0
+  - ncurses=5.9=10
+  - networkx=1.11=py35_0
+  - notebook=5.4.0=py35_0
+  - openssl=1.0.2l=0
+  - pandoc=2.1.1=0
+  - pandocfilters=1.4.1=py35_0
+  - parso=0.1.1=py_0
+  - pcre=8.41=h470a237_2
+  - pexpect=4.3.1=py35_0
+  - pickleshare=0.7.4=py35_0
+  - pip=9.0.1=py35_1
+  - prompt_toolkit=1.0.15=py35_0
+  - pthread-stubs=0.4=h470a237_1
+  - ptyprocess=0.5.2=py35_0
+  - pygments=2.2.0=py35_0
+  - pyparsing=2.2.0=py35_0
+  - pyqt=5.6.0=py35h8210e8a_6
+  - python=3.5.4=0
+  - python-dateutil=2.6.1=py35_0
+  - pytz=2017.2=py35_0
+  - pyyaml=3.12=py35_1
+  - pyzmq=16.0.2=py35_3
+  - send2trash=1.4.2=py_0
+  - simplegeneric=0.8.1=py35_0
+  - sip=4.18=py35_0
+  - six=1.10.0=py35_0
+  - sqlite=3.13.0=0
+  - sympy=1.1.1=py35_0
+  - terminado=0.8.1=py35_0
+  - testpath=0.3.1=py35_0
+  - tornado=4.5.3=py35_0
+  - traitlets=4.3.2=py35_0
+  - wcwidth=0.1.7=py35_0
+  - webencodings=0.5=py35_0
+  - wheel=0.29.0=py35_0
+  - widgetsnbextension=3.1.3=py35_0
+  - xorg-libxau=1.0.8=h470a237_6
+  - xorg-libxdmcp=1.1.2=h470a237_7
+  - xz=5.2.3=0
+  - yaml=0.1.7=0
+  - zeromq=4.2.1=1
+  - zlib=1.2.11=0
+  - fontconfig=2.12.1=3
+  - freetype=2.5.5=2
+  - icu=54.1=0
+  - libgcc=7.2.0=h69d50b8_2
+  - libgcc-ng=7.2.0=hdf63c60_3
+  - libgfortran=3.0.0=1
+  - libpng=1.6.30=1
+  - libstdcxx-ng=7.2.0=hdf63c60_3
+  - libxml2=2.9.4=0
+  - matplotlib=2.0.2=np113py35_0
+  - mkl=2017.0.3=0
+  - numpy=1.13.1=py35_0
+  - qt=5.6.2=5
+  - readline=6.2=2
+  - scipy=0.19.1=np113py35_0
+  - setuptools=36.4.0=py35_1
+  - tk=8.5.18=0
+  - pip:
+    - antlr4-python3-runtime==4.5.3
+    - graphviz==0.8.2
+    - pydstool==0.90.2
+    - .
+prefix: /home/will/miniconda3/envs/testing123
 

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# run matplotlib once to generate the font cache
+python -c "import matplotlib as mpl; mpl.use('Agg'); import pylab as plt; fig, ax = plt.subplots(); fig.savefig('test.png')"
+
+test -e test.png && rm test.png

--- a/postBuild
+++ b/postBuild
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Not needed if installed ipywidgets using conda
+#jupyter nbextension enable --py widgetsnbextension --sys-prefix
+
+# Enable per-Notebook table of contents in Jupyter UI 
+# First, configure jupyter_contrib_nbextensions: the following "copies the
+# nbextensions' javascript and css files into the jupyter server's search
+# directory"
+jupyter contrib nbextension install --sys-prefix
+# Second, enable the TOC2 extension
+jupyter nbextension enable toc2/main
+
+# Enable Nbextensions tab in Jupyter UI; should not be necessary if installed nbextensions_configurator using conda
+#jupyter nbextensions_configurator enable --sys-prefix
+
 # run matplotlib once to generate the font cache
 python -c "import matplotlib as mpl; mpl.use('Agg'); import pylab as plt; fig, ax = plt.subplots(); fig.savefig('test.png')"
 


### PR DESCRIPTION
* Fix `environment.yml` so works on Linux
* Ensure LaTeX and graphviz installed using apt when mybinder.org builds Docker container
* Ensure TOC2 (table of contents) Jupyter extension installed by default
* Add button to README for launching User Manual in mybinder.org

See Issue #163 