### PR TITLE
Remove output cells from user manual Notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ This:
     (using [nbval](https://github.com/computationalmodelling/nbval)).
     If an Exception/Error is encountered then a Jupyter tab is opened in the default web browser showing its location 
     (using [nbdime](https://nbdime.readthedocs.io/en/stable/)).
+ 1. Checks that the user manual notebook does not contain output cells
 
 <!--1. Checks that the [docs/MuMoTuserManual.ipynb](docs/MuMoTuserManual.ipynb) and [TestNotebooks/MuMoTtest.ipynb](TestNotebooks/MuMoTtest.ipynb) Notebooks 
     generate the same output cell content as is saved in the Notebook files when re-run 
@@ -210,6 +211,8 @@ If you want to contribute a feature or fix a bug then:
           [TestNotebooks/MuMoTtest.ipynb](TestNotebooks/MuMoTtest.ipynb) or test notebooks to [TestNotebooks/MiscTests/](TestNotebooks/MiscTests). 
     * Documentation: Include Python docstrings documentation in the [numpydoc](http://numpydoc.readthedocs.io/en/latest/format.html) format 
       for all modules, functions, classes, methods and (if applicable) attributes.
+    * Do not commit an updated user manual Notebook containing output cells; all output cells should be stripped first using: 
+      ``jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace docs/MuMoTuserManual.ipynb``
     * Use `@todo` for reminders.
 * When you are ready to merge that into the `master` branch of the 'upstream' repository:
     * Run all tests using `tox` (see [Testing](#testing)) *first*.

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'networkx',
         'pydstool',
         'scipy<1.0.0',  # see https://github.com/DiODeProject/MuMoT/issues/63
-        'sympy>=1.1.1',
+        'sympy >= 1.1.1, < 1.3'  # see https://github.com/DiODeProject/MuMoT/issues/170
         ],
     extras_require={
         'test': [

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'graphviz',
         'ipython',
         'ipywidgets',
-        'matplotlib',
+        'matplotlib<3.0',  # see https://github.com/DiODeProject/MuMoT/issues/171
         'networkx',
         'pydstool',
         'scipy<1.0.0',  # see https://github.com/DiODeProject/MuMoT/issues/63

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,10 @@ envlist = py36
 extras = test
 passenv = DISPLAY BROWSER
 install_command = pip install {opts} {packages}
+whitelist_externals = 
+    bash
+    test
+    wc
 commands = 
     # Ensure ipywidgets Jupyter extension is installed
     jupyter nbextension enable --py --sys-prefix widgetsnbextension
@@ -12,6 +16,7 @@ commands =
     # Ensure the user manual and regression test Notebooks run *without errors* (do not check for regressions yet)
     pytest --maxfail=1 --nbval-lax --nbdime docs/MuMoTuserManual.ipynb
     pytest --maxfail=1 --nbval-lax --nbdime TestNotebooks/MuMoTtest.ipynb
+
     #pytest --maxfail=1 --cov={envsitepackagesdir}/mumot --nbval-lax --nbdime TestNotebooks/MuMoTtest.ipynb  # Enable when https://github.com/DiODeProject/MuMoT/issues/157 fixed
     #pytest --maxfail=1 --nbval-lax --nbdime TestNotebooks/MiscTests/MuMoTtest_GreekLetters.ipynb
     #pytest --maxfail=1 --nbval-lax --nbdime TestNotebooks/MiscTests/MuMoTtest_MasterEq.ipynb
@@ -19,6 +24,10 @@ commands =
     #pytest --maxfail=1 --nbval-lax --nbdime TestNotebooks/MiscTests/MuMoTtest_bifurcation.ipynb
     #pytest --maxfail=1 --nbval-lax --nbdime TestNotebooks/MiscTests/MuMoTtest_oneDimensionalModels.ipynb
     #pytest --maxfail=1 --nbval-lax --nbdime TestNotebooks/MiscTests/MuMoTuserManual_for_LabPresentation.ipynb
+
     # Ensure the user manual and regression test Notebooks do not show regressions
     #pytest --nbval --nbdime docs/MuMoTuserManual.ipynb
     #pytest --nbval --nbdime TestNotebooks/MuMoTtest.ipynb
+
+    # Check user manual does not contain output cells
+    bash -c 'test $(nbshow --outputs docs/MuMoTuserManual.ipynb | wc -c) -eq 0'  


### PR DESCRIPTION
And add a test (in `tox.ini`) that will fail if the user manual Notebook contains output cells.

Addresses Issue #164