### PR TITLE
Try running just tox within Travis job to unify local and CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,6 @@ python:
 before_install:
   - sudo apt-get install -y texlive graphviz dvipng
 install:
-  - pip install .[test,docs]
-before_script:
-  - jupyter nbextension enable --py --sys-prefix widgetsnbextension
-# 1. Run unit tests
-# 2. Ensure the user manual and regression test Notebooks run *without errors* (do not check for regressions yet)
-# 3. Check that Sphinx documentation will build
-script:
-  - pytest --cov mumot tests
-  - pytest --maxfail=1 --nbval-lax docs/MuMoTuserManual.ipynb
-  - pytest --maxfail=1 --nbval-lax TestNotebooks/MuMoTtest.ipynb
-  - make --directory docs html
+  - pip install tox-travis
+script: 
+  - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,9 @@
 [tox]
 envlist = py36
 [testenv]
-extras = test
+extras = 
+    test
+    docs
 passenv = DISPLAY BROWSER
 install_command = pip install {opts} {packages}
 whitelist_externals = 
@@ -31,3 +33,6 @@ commands =
 
     # Check user manual does not contain output cells
     bash -c 'test $(nbshow --outputs docs/MuMoTuserManual.ipynb | wc -c) -eq 0'  
+
+    # Check we can build the docs
+    make --directory docs html

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ whitelist_externals =
     bash
     test
     wc
+    make
 commands = 
     # Ensure ipywidgets Jupyter extension is installed
     jupyter nbextension enable --py --sys-prefix widgetsnbextension


### PR DESCRIPTION
Explanation: The tox config in this repo can be used to automatically run tests in an isolated local environment.  For some reason (I forget the specifics) I originally set up Travis CI so it ran a separately defined set of tests and did not just run tox.  

This PR removes the Travis-specific tests from the Travis job config and tells Travis to just run tox, thus unifiying the local and CI service testing mechanisms.