### PR TITLE
Tweaks to codecov setup

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+branch = True
+source = mumot
+
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+ignore_errors = True
+omit =
+    tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ python:
 before_install:
   - sudo apt-get install -y texlive graphviz dvipng
 install:
-  - pip install tox-travis
+  - pip install tox-travis codecov
 script: 
   - tox
-  - bash <(curl -s https://codecov.io/bash)
+  - ls -l .coverage
+  - codecov


### PR DESCRIPTION
 - Try using Python codecov uploader
 - Add check in `.travis.yml` for existence of `.coverage` file 
 - Add fairly generic `.coveragerc` config file

Goal is to get the codecov uploader to find and upload the data in .coverage; to date it reports not being able to find any coverage data to upload (https://github.com/DiODeProject/MuMoT/issues/157#issuecomment-425023339)