### PR TITLE
Ensure can create models from a string instead of a cell reference

### DIFF
--- a/TestNotebooks/MuMoTtest.ipynb
+++ b/TestNotebooks/MuMoTtest.ipynb
@@ -33,8 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%model\n",
-    "$\n",
+    "model1 = mumot.parseModel(r\"\"\"\n",
     "U -> A : g_1\n",
     "U -> B : g_2\n",
     "A -> U : a_1\n",
@@ -43,16 +42,7 @@
     "B + U -> B + B : r_2\n",
     "A + B -> A + U : s\n",
     "A + B -> B + U : s\n",
-    "$"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model1 = mumot.parseModel(In[2])"
+    "\"\"\")"
    ]
   },
   {
@@ -434,8 +424,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%model\n",
-    "$\n",
+    "model7 = mumot.parseModel(r\"\"\"\n",
     "U -> A : g_1\n",
     "U -> B : g_2\n",
     "U -> C : g_3\n",
@@ -451,16 +440,7 @@
     "A + C -> C + U : s\n",
     "B + C -> B + U : s\n",
     "B + C -> C + U : s\n",
-    "$"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model7 = mumot.parseModel(In[38])"
+    "\"\"\")"
    ]
   },
   {
@@ -503,22 +483,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%model\n",
-    "$\n",
+    "model9 = mumot.parseModel(r\"\"\"\n",
     "(\\alpha) -> X : \\gamma\n",
     "X + X + Y -> X + X + X : \\chi\n",
     "(\\beta) + X -> Y + \\emptyset : \\delta\n",
     "X -> \\emptyset : \\xi\n",
-    "$"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model9 = mumot.parseModel(In[43])"
+    "\"\"\")"
    ]
   },
   {

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1,4 +1,9 @@
-from mumot import MuMoTmodel
+from textwrap import dedent
+
+from mumot import (
+    MuMoTmodel,
+    parseModel
+)
 
 
 def test_dummy_1():
@@ -15,3 +20,22 @@ def test_dummy_2():
     More information about this test.
     """
     assert 2 == 2
+
+
+def test_parse_model_from_cell_contents():
+    """Assert we can instantiate a MuMoTmodel from the contents of a Notebook cell that uses the %%model cell magic."""
+    s = "get_ipython().run_cell_magic('model', '', '$\\nU -> A : g_A\\nU -> B : g_B\\nA -> U : a_A\\nB -> U : a_B\\nA + U -> A + A : r_A\\nB + U -> B + B : r_B\\nA + B -> A + U : s\\nA + B -> B + U : s\\n$\\n')"
+    parseModel(s)
+
+
+def test_parse_model_from_str():
+    """Assert we can instantiate a MuMoTmodel from a multi-line string."""
+    s = dedent("""U -> A : g_A
+        U -> B : g_B
+        A -> U : a_A
+        B -> U : a_B
+        A + U -> A + A : r_A
+        B + U -> B + B : r_B
+        A + B -> A + U : s
+        A + B -> B + U : s""")
+    parseModel(s)

--- a/tox.ini
+++ b/tox.ini
@@ -21,9 +21,9 @@ commands =
 
     # Ensure the user manual and regression test Notebooks run *without errors* (do not check for regressions yet)
     pytest --maxfail=1 --nbval-lax --nbdime docs/MuMoTuserManual.ipynb
-    pytest --maxfail=1 --nbval-lax --nbdime TestNotebooks/MuMoTtest.ipynb
+    pytest --maxfail=1 --nbval-lax --nbdime --cov={envsitepackagesdir}/mumot --cov-append TestNotebooks/MuMoTtest.ipynb
 
-    # Additional example Notebooks (do not enable yet)
+    # Additional example Notebooks (TODO; leave commented)
     #pytest --maxfail=1 --cov={envsitepackagesdir}/mumot --nbval-lax --nbdime TestNotebooks/MuMoTtest.ipynb  # Enable when https://github.com/DiODeProject/MuMoT/issues/157 fixed
     #pytest --maxfail=1 --nbval-lax --nbdime TestNotebooks/MiscTests/MuMoTtest_GreekLetters.ipynb
     #pytest --maxfail=1 --nbval-lax --nbdime TestNotebooks/MiscTests/MuMoTtest_MasterEq.ipynb
@@ -32,7 +32,7 @@ commands =
     #pytest --maxfail=1 --nbval-lax --nbdime TestNotebooks/MiscTests/MuMoTtest_oneDimensionalModels.ipynb
     #pytest --maxfail=1 --nbval-lax --nbdime TestNotebooks/MiscTests/MuMoTuserManual_for_LabPresentation.ipynb
 
-    # Ensure the user manual and regression test Notebooks do not show regressions (do not enable yet)
+    # Ensure the user manual and regression test Notebooks do not show regressions (TODO; leave commented)
     #pytest --nbval --nbdime TestNotebooks/MuMoTtest.ipynb
 
     # Check user manual does not contain output cells


### PR DESCRIPTION
Directly addresses #156.  Could also help with #157 (measuring code coverage during Notebook runs). 