### PR TITLE
Restrict ipykernel, tornado and pyzmq versions so do not get extra figs when wiggle ipywidgets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,13 +30,16 @@ setup(
     install_requires=[
         'antlr4-python3-runtime==4.5.3',
         'graphviz',
+        'ipykernel<4.7',  # needed so no duplicate figures when wiggle ipywidgets
         'ipython',
         'ipywidgets',
         'matplotlib<3.0',  # see https://github.com/DiODeProject/MuMoT/issues/171
         'networkx',
         'pydstool',
+        'pyzmq<17',  # needed if using tornado < 5
         'scipy<1.0.0',  # see https://github.com/DiODeProject/MuMoT/issues/63
         'sympy >= 1.1.1, < 1.3'  # see https://github.com/DiODeProject/MuMoT/issues/170
+        'tornado<5'  # needed to avoid errors with older ipykernel
         ],
     extras_require={
         'test': [


### PR DESCRIPTION
Hopefully fixes Issue #158 (and #100 can be closed if this works too as all dependencies will be defined in `setup.py`) 