### PR TITLE
Fix user manual cell reference and enable better test output

### DIFF
--- a/docs/MuMoTuserManual.ipynb
+++ b/docs/MuMoTuserManual.ipynb
@@ -1353,7 +1353,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model7 = mumot.parseModel(In[41])"
+    "model7 = mumot.parseModel(In[44])"
    ]
   },
   {

--- a/tox.ini
+++ b/tox.ini
@@ -20,20 +20,23 @@ commands =
     pytest --cov={envsitepackagesdir}/mumot tests
 
     # Ensure the user manual and regression test Notebooks run *without errors* (do not check for regressions yet)
-    pytest --maxfail=1 --nbval-lax --nbdime docs/MuMoTuserManual.ipynb
-    pytest --maxfail=1 --nbval-lax --nbdime --cov={envsitepackagesdir}/mumot --cov-append TestNotebooks/MuMoTtest.ipynb
+    # (add --nbdime if running tox locally and want to visualise/explore diffs in web browser)
+    pytest --verbose --maxfail=1 --nbval-lax docs/MuMoTuserManual.ipynb
+    pytest --verbose --maxfail=1 --nbval-lax --cov={envsitepackagesdir}/mumot --cov-append TestNotebooks/MuMoTtest.ipynb
 
     # Additional example Notebooks (TODO; leave commented)
+    # (add --nbdime if running tox locally and want to visualise/explore diffs in web browser)
     #pytest --maxfail=1 --cov={envsitepackagesdir}/mumot --nbval-lax --nbdime TestNotebooks/MuMoTtest.ipynb  # Enable when https://github.com/DiODeProject/MuMoT/issues/157 fixed
-    #pytest --maxfail=1 --nbval-lax --nbdime TestNotebooks/MiscTests/MuMoTtest_GreekLetters.ipynb
-    #pytest --maxfail=1 --nbval-lax --nbdime TestNotebooks/MiscTests/MuMoTtest_MasterEq.ipynb
-    #pytest --maxfail=1 --nbval-lax --nbdime TestNotebooks/MiscTests/MuMoTtest_NoiseFixedPoints.ipynb
-    #pytest --maxfail=1 --nbval-lax --nbdime TestNotebooks/MiscTests/MuMoTtest_bifurcation.ipynb
-    #pytest --maxfail=1 --nbval-lax --nbdime TestNotebooks/MiscTests/MuMoTtest_oneDimensionalModels.ipynb
-    #pytest --maxfail=1 --nbval-lax --nbdime TestNotebooks/MiscTests/MuMoTuserManual_for_LabPresentation.ipynb
+    #pytest --maxfail=1 --nbval-lax TestNotebooks/MiscTests/MuMoTtest_GreekLetters.ipynb
+    #pytest --maxfail=1 --nbval-lax TestNotebooks/MiscTests/MuMoTtest_MasterEq.ipynb
+    #pytest --maxfail=1 --nbval-lax TestNotebooks/MiscTests/MuMoTtest_NoiseFixedPoints.ipynb
+    #pytest --maxfail=1 --nbval-lax TestNotebooks/MiscTests/MuMoTtest_bifurcation.ipynb
+    #pytest --maxfail=1 --nbval-lax TestNotebooks/MiscTests/MuMoTtest_oneDimensionalModels.ipynb
+    #pytest --maxfail=1 --nbval-lax TestNotebooks/MiscTests/MuMoTuserManual_for_LabPresentation.ipynb
 
     # Ensure the user manual and regression test Notebooks do not show regressions (TODO; leave commented)
-    #pytest --nbval --nbdime TestNotebooks/MuMoTtest.ipynb
+    # (add --nbdime if running tox locally and want to visualise/explore diffs in web browser)
+    #pytest --nbval TestNotebooks/MuMoTtest.ipynb
 
     # Check user manual does not contain output cells
     bash -c 'test $(nbshow --outputs docs/MuMoTuserManual.ipynb | wc -c) -eq 0'  


### PR DESCRIPTION
 - Corrects an explicit cell ref used to instantiate the variable `model7` (should reference a MuMoT model but previously was just assigned `None`.
 - Enables more verbose (per-cell) pytest output
 - Disables the display of nbval fails in the browser (problematic on remote machines as there's no display/browser!)
    - CI logs should be much more informative now if nbval encounters cells that raise unhandled Exceptions/Errors. 