### PR TITLE
Fixed issues #223 #277 #256

### DIFF
--- a/TestNotebooks/MuMoTtest.ipynb
+++ b/TestNotebooks/MuMoTtest.ipynb
@@ -293,9 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "modelStreamCont1 = model4.stream('A', 'B',fontsize=25, xlab=r'this is the x-label', \n",
@@ -364,9 +362,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "model4.SSA()"
@@ -389,6 +385,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "ssa.showLogs()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "ma = model4.multiagent()"
    ]
   },
@@ -401,6 +406,15 @@
     "model4.multiagent(initWidgets={'realtimePlot':True, 'systemSize':[50,3,100,1],\n",
     "                        'initialState':{'U': [1,0,1,0.01],'B': [0,0,1,0.1],'A': [0,0,1,0.1]},\n",
     "                        'netType':'dynamic', 'visualisationType':'graph', 'showTrace':True, 'showInteractions':True})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ma.showLogs()"
    ]
   },
   {
@@ -658,9 +672,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "soloView1 = mumot.MuMoTbifurcationView(model4, None,\n",
@@ -677,7 +689,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "soloView2 = mumot.MuMoTstreamView(model6, None, None, 'A', 'B', params = [('s', 1), ('v', 2)])"
+    "soloView2 = mumot.MuMoTstreamView(model6, None, {'maxTime':1,'runs':5,'randomSeed':123,'aggregateResults':True}, None, 'A', 'B', params = [('s', 1), ('v', 2)])"
    ]
   },
   {
@@ -695,7 +707,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "soloView3 = mumot.MuMoTvectorView(model10, None, None, 'A', 'B', 'C', params = [('s', 5), ('a', 1/2), ('r', 5), ('g', 1)])"
+    "soloView3 = mumot.MuMoTvectorView(model10, None, {'maxTime':1,'runs':5,'randomSeed':123,'aggregateResults':True}, None, 'A', 'B', 'C', params = [('s', 5), ('a', 1/2), ('r', 5), ('g', 1)])"
    ]
   },
   {
@@ -719,9 +731,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mumot.MuMoTmultiagentView(model4, None, params = [('\\\\Delta', 2.0), ('\\\\mu', 2.0), ('s', 2.0), ('plotLimits', 1), ('systemSize', 15)], SSParams = {'maxTime': 3.0, 'netType': 'erdos-renyi', 'realtimePlot': False, 'netParam': 0.2, 'aggregateResults': True, 'randomSeed': 1440908719, 'timestepSize': 0.136363636363636, 'plotProportions': False, 'initialState': {'A': 0.0, 'U': 1.0, 'B': 0.0}, 'runs': 3, 'visualisationType': 'evo'} )"
@@ -737,9 +747,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "multiController1 = mumot.MuMoTmultiController([model4.stream('A', 'B', silent = True, showFixedPoints=False), \n",
@@ -758,9 +766,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "multiController2 = mumot.MuMoTmultiController([model4.vector('A', 'B', silent = True, showFixedPoints=False), \n",
@@ -790,9 +796,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "multiController4 = mumot.MuMoTmultiController([model4.bifurcation('s','A', silent = True), \n",
@@ -803,9 +807,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#mtc = mumot.MuMoTmultiController([\n",
@@ -823,9 +825,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mc1 = mumot.MuMoTmultiController([model4.SSA(initWidgets={'initialState':{'U': [1,0,1,0.01],'B': [0,0,1,0.1],\n",
@@ -926,7 +926,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bookmark2 = model9.stream('X', 'Y', params = [('\\\\alpha', 0.5), ('\\\\xi', 0.5), ('\\\\delta', 0.5), ('\\\\chi', 0.5), ('\\\\beta', 0.5), ('\\\\gamma', 0.5), ('plotLimits', 1.0), ('systemSize', 1)], showFixedPoints = False, bookmark = False)"
+    "bookmark2 = model9.stream('X', 'Y', params = [('\\\\alpha', 0.5), ('\\\\xi', 0.5), ('\\delta', 0.5), ('\\\\chi', 0.5), ('\\\\beta', 0.5), ('\\\\gamma', 0.5), ('plotLimits', 1.0), ('systemSize', 1)], showFixedPoints = False, bookmark = False)"
    ]
   },
   {
@@ -944,7 +944,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bookmark3 = model4.vector('A', 'B', params = [('\\\\mu', 0.5), ('s', 0.5), ('\\\\Delta', 0.5), ('plotLimits', 1), ('systemSize', 1)], showFixedPoints = True, bookmark = False)"
+    "bookmark3 = model4.vector('A', 'B', params = [('\\\\mu', 0.5), ('s', 10.5), ('\\\\Delta', 0.5), ('plotLimits', 1), ('systemSize', 1)], showFixedPoints = False, bookmark = False)"
    ]
   },
   {
@@ -995,9 +995,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "bookmark8 = model4.multiagent(params = [('\\\\Delta', 2.0), ('s', 2.0), ('\\\\mu', 2.0), ('plotLimits', 1), ('systemSize', 25)], initialState = {'B': 0.0, 'U': 1.0, 'A': 0.0}, maxTime = 3.0, timestepSize = 0.13636363636363635, randomSeed = 214748364, netType = 'barabasi-albert', netParam = 3.0, visualisationType = 'graph', plotProportions = False, realtimePlot = False, runs = 1, aggregateResults = True, silent = False, bookmark = False)"

--- a/mumot/__init__.py
+++ b/mumot/__init__.py
@@ -3804,7 +3804,6 @@ class MuMoTtimeEvolutionView(MuMoTview):
             if 'plotProportions' in self._tEParams: # @todo JARM: I don't really understand logic of checking _tEParams but then retrieving the value from elsewhere
                 self._plotProportions = self._getWidgetParamValue('plotProportions', self._controller._widgetsPlotOnly) # self._fixedParams['plotProportions'] if self._fixedParams.get('plotProportions') is not None else self._controller._widgetsPlotOnly['plotProportions'].value
             self._maxTime = self._getWidgetParamValue('maxTime', self._controller._widgetsExtraParams) # self._fixedParams['maxTime'] if self._fixedParams.get('maxTime') is not None else self._controller._widgetsExtraParams['maxTime'].value
-
                
 #      
 #     def _get_tEParams(self):
@@ -4187,13 +4186,12 @@ class MuMoTnoiseCorrelationsView(MuMoTtimeEvolutionView):
         self._logs.append(log)
          
         argDict = self._get_argDict()
-        for key in argDict:
-            if key in self._mumotModel._constantReactants:
+        for key in self._mumotModel._constantReactants:
+            if argDict[key] is not None:
                 argDict[Symbol('Phi_'+str(key))] = argDict.pop(key)
         for key in steadyStateDict:
             if key in self._mumotModel._reactants:
                 steadyStateDict[Symbol('Phi_'+str(key))] = steadyStateDict.pop(key)
-        
         EOM_1stOrdMomDict = copy.deepcopy(self._EOM_1stOrdMomDict)
         for sol in EOM_1stOrdMomDict:
             EOM_1stOrdMomDict[sol] = EOM_1stOrdMomDict[sol].subs(steadyStateDict)
@@ -4298,9 +4296,6 @@ class MuMoTnoiseCorrelationsView(MuMoTtimeEvolutionView):
             self._showErrorMessage('Could not compute Second Order Moments. Could not generate figure. Try different initial conditions in the Advanced options tab! ')
             return None
                 
-        #print(time)
-        #print(y0)
-        #print(SOL_2ndOrdMomDict)
         sol_ODE = odeint(noiseODEsys, y0, time)  # sol_ODE overwritten
         
         x_data = [time for kk in range(len(y0))]  

--- a/mumot/__init__.py
+++ b/mumot/__init__.py
@@ -2146,11 +2146,16 @@ class MuMoTcontroller:
     def _displayAdvancedOptionsTab(self):
         """create and display the "Advanced options" tab (if not empty)"""
         advancedWidgets = []
+        atLeastOneAdvancedWidget = False
         for widgetName in self._extraWidgetsOrder:
             if self._widgetsExtraParams.get(widgetName):
                 advancedWidgets.append(self._widgetsExtraParams[widgetName])
+                if not self._widgetsExtraParams[widgetName].layout.display == 'none':
+                    atLeastOneAdvancedWidget = True
             elif self._widgetsPlotOnly.get(widgetName):
                 advancedWidgets.append(self._widgetsPlotOnly[widgetName])
+                if not self._widgetsPlotOnly[widgetName].layout.display == 'none':
+                    atLeastOneAdvancedWidget = True
             #else:
                 #print("WARNING! In the _extraWidgetsOrder is listed the widget " + widgetName + " which is although not found in _widgetsExtraParams or _widgetsPlotOnly")
         if advancedWidgets:  # if not empty
@@ -2159,7 +2164,7 @@ class MuMoTcontroller:
             self._advancedTabWidget = widgets.Accordion(children=[advancedPage])  # , selected_index=-1)
             self._advancedTabWidget.set_title(0, 'Advanced options')
             self._advancedTabWidget.selected_index = None
-            display(self._advancedTabWidget)
+            if atLeastOneAdvancedWidget: display(self._advancedTabWidget)
 
 
     def setView(self, view):
@@ -2455,9 +2460,6 @@ class MuMoTfieldController(MuMoTcontroller):
     
         return None
             
-    def _addSpecificWidgets(self, SSParams, continuousReplot):
-        pass
-    
     def _orderAdvancedWidgets(self, _noInitialState):
         # define the widget order
 #         self._extraWidgetsOrder.append('final_x')

--- a/mumot/__init__.py
+++ b/mumot/__init__.py
@@ -493,11 +493,11 @@ class MuMoTmodel:
 #            display(Math(self._ratesLaTeX[rate]))
 
     def showSingleAgentRules(self):
-        """Show the probabilistic transition of the agents in each
-        reactant-state.
+        """Show the probabilistic transitions of the agents in each possible reactant-state.
 
-        Prints strings.
-
+        Returns
+        -------
+            `None`
         """
         if not self._agentProbabilities:
             self._getSingleAgentRules()
@@ -1477,51 +1477,55 @@ class MuMoTmodel:
         
         Parameters
         ----------
-        initWidgets : dict, optional
+        initWidgets : dict {str,list}, optional
            Keys are the free-parameter or any other specific parameter, and values are four values as [initial-value, min-value, max-value, step-size]
 
         Other Parameters
         ----------------
-        initialState : float 
-           Initial proportions of the reactants; a value in the range [0,1].
-        maxTime : float
-           Simulation time; must be > 0.
-        randomSeed : int 
-           Random seed in range [0, MAX_RANDOM_SEED]).
-        plotProportions : bool
-           Flag to plot proportions or full populations.
-        realtimePlot : bool
-           Flag to plot results in realtime (True = the plot is updated each
-           timestep of the simulation; False = the plot is updated once at the
-           end of the simulation).
-        visualisationType : str
-            Type of visualisation (``'evo'``,``'graph'``,``'final'`` or ``'barplot'``).
-        final_x : object
-           Which reactant is shown on x-axis when visualisation type is final.
-        final_y : object
-           Which reactant is shown on x-axis when visualisation type is final.
-        runs : int
-           Number of simulation runs to be executed.
-        aggregateResults : bool
-           Flag to aggregate or not the results from several runs.
-        netType : str
-           Type of network (``'full'``, ``'erdos-renyi'``, ``'barabasi-albert'`` or ``'dynamic'``.
-        netParam : float
-           Property of the network ralated to connectivity. It varies depending on the netType.
-        motionCorrelatedness : float
-           (active only for netType='dynamic') level of inertia in the random walk, with 0 completely uncorrelated random walk and 1 straight trajectories.  Must be in range [0, 1].
-        particleSpeed : float
-           (active only for netType='dynamic') speed of the moving particle,
-           i.e. displacement in one timestep.  Must be in range  [0,1].
-        timestepSize : float
-           Length of one timestep, the maximum size is determined by the rates.
-           Must be > 0.
-        showTrace : bool
-           (active only for netType='dynamic') flag to plot the part trajectory
-           of each particle.
-        showInteractions : bool
-           (active only for netType='dynamic') flag to plot the interaction
-           range between particles.
+        params: list [(str,num)], optional
+            List of parameters defined as pairs ('parameter name', value). See 'Partial controllers' in the docs/MuMoTuserManual.ipynb. Rates defaults to mumot.MuMoTdefault._initialRateValue. System size defaults to mumot.MuMoTdefault._systemSize. 
+        initialState : dictionary {str:float}, optional
+           Initial proportions of the reactants (type: dictionary with reactants as keys and floats in range [0,1] as values).
+           See the bookmark of and example. Defaults to a dictionaly with the (alphabetically) first reactant to 1 and the rest to 0.
+        maxTime : float, optional
+           Simulation time. Must be strictly positive. Defaults to mumot.MuMoTdefault._maxTime.
+        randomSeed : int, optional
+           Random seed. Must be strictly positive in range [0, mumot.MAX_RANDOM_SEED]). Defaults to a random number.
+        plotProportions : bool, optional
+           Flag to plot proportions or full populations. Defaults to False.
+        realtimePlot : bool, optional
+           Flag to plot results in realtime (True = the plot is updated each timestep of the simulation; False = the plot is updated once at the end of the simulation). Defaults to False.
+        visualisationType : str, optional
+            Type of visualisation (``'evo'``,``'graph'``,``'final'`` or ``'barplot'``). See docs/MuMoTuserManual.ipynb for more details. Defaults to 'evo'.
+        final_x : object, optional
+           Which reactant is shown on x-axis when visualisation type is 'final'. Defaults to the alphabetically first reactant.
+        final_y : object, optional
+           Which reactant is shown on y-axis when visualisation type is 'final'. Defaults to the alphabetically second reactant.
+        runs : int, optional
+           Number of simulation runs to be executed. Must be strictly positive. Defaults to 1.
+        aggregateResults : bool, optional
+           Flag to aggregate or not the results from several runs. Defaults to True.
+        netType : str, optional
+           Type of network (``'full'``, ``'erdos-renyi'``, ``'barabasi-albert'`` or ``'dynamic'``. See docs/MuMoTuserManual.ipynb for more details. Defaults to 'full'.
+        netParam : float, optional
+           Property of the network ralated to connectivity. The precise meaning and range of this parameter varies depending on the netType. See docs/MuMoTuserManual.ipynb for more details and defaults.
+        motionCorrelatedness : float, optional
+           (active only for netType='dynamic') level of inertia in the random walk, with 0 the reactants do a completely uncorrelated random walk and with 1 they move on straight trajectories. Must be in range [0, 1]. Defaults to 0.5.
+        particleSpeed : float, optional
+           (active only for netType='dynamic') speed of the moving particle, i.e. displacement in one timestep. Must be in range [0,1]. Defaults to 0.01.
+        timestepSize : float, optional
+           Length of one timestep, the maximum size is automatically determined by the rates. Must be strictly positive. Defaults to the maximum value.
+        showTrace : bool, optional
+           (active only for netType='dynamic') flag to plot the trajectory of each reactant. Defaults to False.
+        showInteractions : bool, optional
+           (active only for netType='dynamic') flag to plot the interaction range between particles. Defaults to False.
+        silent : bool, optional
+            Switch on/off widgets and plot. Important for use with multicontrollers. Defaults to False.
+            
+        Returns
+        -------
+        :class:`MuMoTmultiagentController`
+            A MuMoT controller object
         """
         if initWidgets is None:
             initWidgets = dict()
@@ -1573,45 +1577,45 @@ class MuMoTmodel:
         return viewController
 
     def SSA(self, initWidgets=None, **kwargs):
-        """Construct interactive SSA plot (simulation run of the Gillespie
-        algorithm to approximate the Master Equation solution).
+        """Construct interactive Stochastic Simulation Algorithm (SSA) plot (simulation run of the Gillespie algorithm to approximate the Master Equation solution).
 
         Parameters
         ----------
-        initWidgets : dict, optional
-            Keys are the free parameter or any other specific parameter, and
-            values are four values as ``[initial-value, min-value, max-value,
-            step-size]``.
+        initWidgets : dict {str,list}, optional
+           Keys are the free-parameter or any other specific parameter, and values are four values as [initial-value, min-value, max-value, step-size]
 
         Other Parameters
         ----------------
-        initialState : float
-            Initial proportions of the reactants.  Must be value in the
-            range [0,1].
-        maxTime : float
-            Simulation time.  Must be strictly positive.
-        randomSeed : int
-            Random seed.  Must be in range [0, ``MAX_RANDOM_SEED``].
-        plotProportions: bool
-            Flag to plot proportions or full populations.
-        realtimePlot : bool
-            Flag to plot results in realtime.  If True, the plot is updated
-            each timestep of the simulation; if  False, the plot is updated
-            once at the end of the simulation.
-        visualisationType : str
-            Type of visualisation.  Must be one of: ``'evo'``, ``'graph'``,
-            ``'final'``, ``'barplot'``.
-        final_x
-            Which reactant is shown on x-axis when visualisation type is
-            ``'final'``.  Type?
-        final_y
-            Which reactant is shown on x-axis when visualisation type is
-            ``'final'``.  Type?
-        runs: int
-            Number of simulation runs to be executed.
-        aggregateResults: bool
-            Flag to aggregate or not the results from several runs.
-
+        params: list [(str,num)], optional
+            List of parameters defined as pairs ('parameter name', value). See 'Partial controllers' in the docs/MuMoTuserManual.ipynb. Rates defaults to mumot.MuMoTdefault._initialRateValue. System size defaults to mumot.MuMoTdefault._systemSize. 
+        initialState : dictionary {str:float}, optional
+           Initial proportions of the reactants (type: dictionary with reactants as keys and floats in range [0,1] as values).
+           See the bookmark of and example. Defaults to a dictionaly with the (alphabetically) first reactant to 1 and the rest to 0.
+        maxTime : float, optional
+           Simulation time. Must be strictly positive. Defaults to mumot.MuMoTdefault._maxTime.
+        randomSeed : int, optional
+           Random seed. Must be strictly positive in range [0, mumot.MAX_RANDOM_SEED]). Defaults to a random number.
+        plotProportions : bool, optional
+           Flag to plot proportions or full populations. Defaults to False.
+        realtimePlot : bool, optional
+           Flag to plot results in realtime (True = the plot is updated each timestep of the simulation; False = the plot is updated once at the end of the simulation). Defaults to False.
+        visualisationType : str, optional
+            Type of visualisation (``'evo'``,``'final'`` or ``'barplot'``). See docs/MuMoTuserManual.ipynb for more details. Defaults to 'evo'.
+        final_x : object, optional
+           Which reactant is shown on x-axis when visualisation type is 'final'. Defaults to the alphabetically first reactant.
+        final_y : object, optional
+           Which reactant is shown on y-axis when visualisation type is 'final'. Defaults to the alphabetically second reactant.
+        runs : int, optional
+           Number of simulation runs to be executed. Must be strictly positive. Defaults to 1.
+        aggregateResults : bool, optional
+           Flag to aggregate or not the results from several runs. Defaults to True.
+        silent : bool, optional
+            Switch on/off widgets and plot. Important for use with multicontrollers. Defaults to False.
+            
+        Returns
+        -------
+        :class:`MuMoTstochasticSimulationController`
+            A MuMoT controller object
         """
         if initWidgets is None:
             initWidgets = {}
@@ -1766,8 +1770,8 @@ class MuMoTmodel:
         return paramValuesDict
 
 
-    ## derive the single-agent rules from reaction rules
     def _getSingleAgentRules(self):
+        """derive the single-agent rules (which are used in the multiagent simulation) from the reaction rules"""
         # create the empty structure
         self._agentProbabilities = {}
         (allReactants, allConstantReactants) = self._getAllReactants()

--- a/mumot/__init__.py
+++ b/mumot/__init__.py
@@ -2151,7 +2151,7 @@ class MuMoTcontroller:
 
     def _print_standalone_view_cmd(self, _):
         self._errorMessage.value = "Pasted bookmark to log - view with showLogs(tail = True)"
-        self._view._print_standalone_view_cmd(False)
+        self._view._print_standalone_view_cmd(True)
 
     ## set the functions that must be triggered when the widgets are changed.
     ## @param[in]    recomputeFunction    The function to be called when recomputing is necessary 

--- a/mumot/__init__.py
+++ b/mumot/__init__.py
@@ -4565,23 +4565,44 @@ class MuMoTfieldView(MuMoTview):
             self._runs = self._getWidgetParamValue('runs', self._controller._widgetsExtraParams) # self._fixedParams['runs'] if self._fixedParams.get('runs') is not None else self._controller._widgetsExtraParams['runs'].value
             self._aggregateResults = self._getWidgetParamValue('aggregateResults', self._controller._widgetsExtraParams) # self._fixedParams['aggregateResults'] if self._fixedParams.get('aggregateResults') is not None else self._controller._widgetsPlotOnly['aggregateResults'].value
 
-    def _build_bookmark(self, includeParams=True):
-        if not self._silent:
-            logStr = "bookmark = "
-        else:
-            logStr = ""
+    def _build_bookmark(self, includeParams=True): 
+        logStr = "bookmark = " if not self._silent else ""
         logStr += "<modelName>." + self._generatingCommand + "('" + str(self._stateVariable1) + "', '" + str(self._stateVariable2) + "', "
         if self._stateVariable3 is not None:
             logStr += "'" + str(self._stateVariable3) + "', "
+        # todo: plotting parameters are not kept, this could be solved with some work on the _generatingKwargs and should be made general for all views (similar to _get_bookmarks_params() )
+#         if includeParams:
+#             logStr += self._get_bookmarks_params() + ", "
+#         if len(self._generatingKwargs) > 0:
+#             for key in self._generatingKwargs:
+#                 if key == 'xlab' or key == 'ylab' or key == 'zlab':
+#                     logStr += key + " = '" + str(self._generatingKwargs[key]) + "', "
+#                 else:
+#                     logStr += key + " = " + str(self._generatingKwargs[key]) + ", "
         if includeParams:
-            logStr += self._get_bookmarks_params() + ", "
-        if len(self._generatingKwargs) > 0:
-            for key in self._generatingKwargs:
-                if key == 'xlab' or key == 'ylab' or key == 'zlab':
-                    logStr += key + " = '" + str(self._generatingKwargs[key]) + "', "
-                else:
-                    logStr += key + " = " + str(self._generatingKwargs[key]) + ", "
-        logStr += "bookmark = False"
+            logStr += self._get_bookmarks_params()
+            logStr += ", "
+        logStr = logStr.replace('\\', '\\\\')
+        logStr += "showNoise = " + str(self._showNoise)
+        logStr += ", showFixedPoints = " + str(self._showFixedPoints)
+        logStr += ", runs = " + str(self._runs)
+        logStr += ", maxTime = " + str(self._maxTime)
+        logStr += ", randomSeed = " + str(self._randomSeed)
+#       todo: Following commented lines are ready to implement issue #95
+#         if self._visualisationType == 'final':
+#             # these loops are necessary to return the latex() format of the reactant 
+#             for reactant in self._mumotModel._getAllReactants()[0]:
+#                 if str(reactant) == self._finalViewAxes[0]:
+#                     logStr += ", final_x = '" + latex(reactant).replace('\\', '\\\\') + "'"
+#                     break
+#             for reactant in self._mumotModel._getAllReactants()[0]:
+#                 if str(reactant) == self._finalViewAxes[1]:
+#                     logStr += ", final_y = '" + latex(reactant).replace('\\', '\\\\') + "'"
+#                     break
+        #logStr += ", plotProportions = " + str(self._plotProportions) todo: ready to implement issue #283
+        logStr += ", aggregateResults = " + str(self._aggregateResults)
+        logStr += ", silent = " + str(self._silent)
+        logStr += ", bookmark = False"
         logStr += ")"
         logStr = _greekPrependify(logStr)
         logStr = logStr.replace('\\', '\\\\')

--- a/mumot/__init__.py
+++ b/mumot/__init__.py
@@ -2918,55 +2918,8 @@ class MuMoTview:
             model = refModel
         else:
             model = self._mumotModel
-         
+        
         params = []
-         
-        paramInitCheck = []
-        for reactant in model._reactants:
-            if reactant not in model._constantReactants:
-                paramInitCheck.append(latex(Symbol('Phi^0_'+str(reactant))))
-                  
-        if self._controller:
-            for name, value in self._controller._widgetsFreeParams.items():
-#                 name = name.replace('\\', '\\\\')
-                if name in model._ratesLaTeX:
-                    name = model._ratesLaTeX[name]
-                name = name.replace('(', '')
-                name = name.replace(')', '')
-                if name not in paramInitCheck:
-                    #logStr += "('" + latex(name) + "', " + str(value.value) + "), "
-                    params.append((latex(name) , value.value))
-#         if self._paramNames is not None:
-#             for name, value in zip(self._paramNames, self._paramValues):
-#                 if name == 'systemSize' or name == 'plotLimits': continue
-#                 name= repr(name)
-#                 if name in model._ratesLaTeX:
-#                     name = model._ratesLaTeX[name]
-#                 name = name.replace('(', '')
-#                 name = name.replace(')', '')
-#                 #logStr += "('" + latex(name) + "', " + str(value) + "), "
-#                 params.append( ( latex(name) , value ) )
-
-        for name, value in self._fixedParams.items():
-            if name == 'systemSize' or name == 'plotLimits': continue
-            name = repr(name)
-            if name in model._ratesLaTeX:
-                name = model._ratesLaTeX[name]
-            name = name.replace('(', '')
-            name = name.replace(')', '')
-            #logStr += "('" + latex(name) + "', " + str(value) + "), "
-            params.append((latex(name) , value))
-        params.append(('plotLimits' , self._getPlotLimits()))
-        params.append(('systemSize' , self._getSystemSize()))
-                 
-        return params
-
-    def _get_bookmarks_params(self, refModel=None):
-        if refModel is not None:
-            model = refModel
-        else:
-            model = self._mumotModel
-        logStr = "params = ["
         
         paramInitCheck = []
         for reactant in model._reactants:
@@ -2975,22 +2928,12 @@ class MuMoTview:
                  
         if self._controller:
             for name, value in self._controller._widgetsFreeParams.items():
-#                 name = name.replace('\\', '\\\\')
                 if name in model._ratesLaTeX:
                     name = model._ratesLaTeX[name]
                 name = name.replace('(', '')
                 name = name.replace(')', '')
                 if name not in paramInitCheck:
-                    logStr += "('" + latex(name) + "', " + str(value.value) + "), "
-#         if self._paramNames is not None:
-#             for name, value in zip(self._paramNames, self._paramValues):
-#                 if name == 'systemSize' or name == 'plotLimits': continue
-#                 name= repr(name)
-#                 if name in model._ratesLaTeX:
-#                     name = model._ratesLaTeX[name]
-#                 name = name.replace('(', '')
-#                 name = name.replace(')', '')
-#                 logStr += "('" + latex(name) + "', " + str(value) + "), "
+                    params.append((latex(name) , value.value))
         for name, value in self._fixedParams.items():
             #if name == 'systemSize' or name == 'plotLimits': continue
             if name not in self._mumotModel._rates and name not in self._mumotModel._constantReactants: continue
@@ -2999,12 +2942,19 @@ class MuMoTview:
                 name = model._ratesLaTeX[name]
             name = name.replace('(', '')
             name = name.replace(')', '')
-            logStr += "('" + latex(name) + "', " + str(value) + "), "
-        logStr += "('plotLimits', " + str(self._getPlotLimits()) + "), "  # @todo is it necessary for every view? I think no.
-        logStr += "('systemSize', " + str(self._getSystemSize()) + "), "
+            params.append((latex(name) , value))
+        params.append(('plotLimits' , self._getPlotLimits()))
+        params.append(('systemSize' , self._getSystemSize()))
+        
+        return params
+
+    def _get_bookmarks_params(self, refModel=None):
+        params = self._get_params(refModel)
+        logStr = "params = ["
+        for name, value in params:
+            logStr += "('" + str(name) + "', " + str(value) + "), "
         logStr = logStr[:-2]  # throw away last ", "
         logStr += "]"
-                
         return logStr        
 
 


### PR DESCRIPTION
The user can now specify through keywords (or via advanced widgets) the simulation details of numerically estimated noise.
To do so, the field controllers and views have been refactored.

Two cells from `TestNotebooks/MuMoTtest.ipynb` have been updated to comply with the structural changes.