### PR TITLE
Migrate coverage path ignore rules to codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+# Do not report coverage of third-party code.  
+# (NB here this is the _installed_ code 
+# in the hidden virtualenv created by tox, 
+# not the source code of the package)
+ignore:
+  - "**/site-packages/mumot/process_latex/*"
+  - "**/site-packages/mumot/gen/*"

--- a/tox.ini
+++ b/tox.ini
@@ -61,9 +61,3 @@ exclude_lines =
     raise NotImplementedError
     if __name__ == .__main__.:
 ignore_errors = True
-; Do not report coverage of third-party code.
-; (NB here this is the _installed_ code in the hidden virtualenv created by tox,
-; not the source code of the package)
-omit =
-    */site-packages/mumot/process_latex/*
-    */site-packages/mumot/gen/*


### PR DESCRIPTION
Testing if this (finally) results in codecov not reporting coverage for 3rd-party sub-packages.