### PR TITLE
Enable testing with Python 3.7 with tox and travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: python
 python:
   - "3.6"
+  - "3.7"
 before_install:
   - sudo apt-get install -y texlive graphviz dvipng
 install:

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -32,12 +32,12 @@ Installing MuMoT within a Conda environment
 
       conda --version
 
-#. Create a new conda environment containing just Python 3.6:
+#. Create a new conda environment containing just Python >=3.6 e.g.:
 
    .. code:: sh
 
       conda update conda
-      conda create -n mumot-env python=3.6
+      conda create -n mumot-env python=3.7
 
 #. Check that conda environment has been created: 
    
@@ -72,7 +72,7 @@ Installing MuMoT within a VirtualEnv
    `this repository <https://github.com/DiODeProject/MuMoT/>`__.
 2. Ensure you have the following installed:
 
-   -  `Python >= 3.4 and <= 3.6 <https://www.python.org/downloads/>`__
+   -  `Python >= 3.6 <https://www.python.org/downloads/>`__
    -  the pip_ package
       manager (usually comes with Python 3.x but might not for certain
       flavours of Linux)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py36, py37
 [testenv]
 extras = 
     test


### PR DESCRIPTION
Possible now that we're no longer tied to using an old scipy (#338).