### PR TITLE
Unpin package dependencies

### DIFF
--- a/mumot/__init__.py
+++ b/mumot/__init__.py
@@ -20,8 +20,8 @@ import matplotlib
 # (e.g. superfluous figures when sliders are moved).
 # Automated testing using tox could be affected as well
 # if default matplotlib backend is used
-if sys.platform == "darwin":
-    matplotlib.use('TkAgg')
+#if sys.platform == "darwin":
+matplotlib.use('TkAgg')
 from matplotlib import pyplot as plt
 from sympy.parsing.latex import parse_latex
 

--- a/mumot/views.py
+++ b/mumot/views.py
@@ -1653,11 +1653,8 @@ class MuMoTfieldView(MuMoTview):
         self._update_params()
         self._show_computation_start()
         if not(self._silent):  # @todo is this necessary?
-            print('here')
             plt.figure(self._figureNum)
-            print('there')
             plt.clf()
-            print('everywhere')
             self._resetErrorMessage()
         self._showErrorMessage(str(self))
 
@@ -2166,7 +2163,9 @@ class MuMoTvectorView(MuMoTfieldView):
 
         if self._stateVariable3 is None:
             self._get_field2d("2d vector plot", 10)  # @todo: allow user to set mesh points with keyword
+            print('foo')
             fig_vector = plt.quiver(self._X, self._Y, self._Xdot, self._Ydot, units='width', color='black')  # @todo: define colormap by user keyword
+            print('bar')
 
             if self._mumotModel._constantSystemSize:
                 plt.fill_between([0, 1], [1, 0], [1, 1], color='grey', alpha='0.25')

--- a/mumot/views.py
+++ b/mumot/views.py
@@ -1653,8 +1653,11 @@ class MuMoTfieldView(MuMoTview):
         self._update_params()
         self._show_computation_start()
         if not(self._silent):  # @todo is this necessary?
+            print('here')
             plt.figure(self._figureNum)
+            print('there')
             plt.clf()
+            print('everywhere')
             self._resetErrorMessage()
         self._showErrorMessage(str(self))
 

--- a/mumot/views.py
+++ b/mumot/views.py
@@ -1653,8 +1653,6 @@ class MuMoTfieldView(MuMoTview):
         self._update_params()
         self._show_computation_start()
         if not(self._silent):  # @todo is this necessary?
-            print(self._figureNum)
-            print(id(plt.figure(self._figureNum)))
             plt.clf()
             self._resetErrorMessage()
         self._showErrorMessage(str(self))

--- a/mumot/views.py
+++ b/mumot/views.py
@@ -1653,7 +1653,7 @@ class MuMoTfieldView(MuMoTview):
         self._update_params()
         self._show_computation_start()
         if not(self._silent):  # @todo is this necessary?
-            plt.figure(self._figureNum)
+            print(id(plt.figure(self._figureNum)))
             plt.clf()
             self._resetErrorMessage()
         self._showErrorMessage(str(self))
@@ -2163,9 +2163,7 @@ class MuMoTvectorView(MuMoTfieldView):
 
         if self._stateVariable3 is None:
             self._get_field2d("2d vector plot", 10)  # @todo: allow user to set mesh points with keyword
-            print('foo')
             fig_vector = plt.quiver(self._X, self._Y, self._Xdot, self._Ydot, units='width', color='black')  # @todo: define colormap by user keyword
-            print('bar')
 
             if self._mumotModel._constantSystemSize:
                 plt.fill_between([0, 1], [1, 0], [1, 1], color='grey', alpha='0.25')

--- a/mumot/views.py
+++ b/mumot/views.py
@@ -1653,6 +1653,7 @@ class MuMoTfieldView(MuMoTview):
         self._update_params()
         self._show_computation_start()
         if not(self._silent):  # @todo is this necessary?
+            print(self._figureNum)
             print(id(plt.figure(self._figureNum)))
             plt.clf()
             self._resetErrorMessage()

--- a/setup.py
+++ b/setup.py
@@ -29,17 +29,17 @@ setup(
     install_requires=[
         'antlr4-python3-runtime',
         'graphviz',
-        'ipykernel<4.7',  # needed so no duplicate figures when wiggle ipywidgets
+        'ipykernel',  # needed so no duplicate figures when wiggle ipywidgets
         'ipython',
         'ipywidgets',
         'matplotlib',
         'networkx',
-        'notebook<5.5',  # needed if using pyzmq < 17
+        'notebook',  # needed if using pyzmq < 17
         'pydstool>=0.90.3',  # min version that allows scipy >= 1.0.0 to be used
-        'pyzmq<17',  # needed if using tornado < 5
+        'pyzmq',  # needed if using tornado < 5
         'scipy',
         'sympy>=1.4',
-        'tornado<5'  # needed to avoid errors with older ipykernel
+        'tornado'  # needed to avoid errors with older ipykernel
     ],
     extras_require={
         'test': [

--- a/setup.py
+++ b/setup.py
@@ -29,17 +29,17 @@ setup(
     install_requires=[
         'antlr4-python3-runtime',
         'graphviz',
-        'ipykernel',  # needed so no duplicate figures when wiggle ipywidgets
+        'ipykernel',
         'ipython',
         'ipywidgets',
         'matplotlib',
         'networkx',
-        'notebook',  # needed if using pyzmq < 17
+        'notebook',
         'pydstool>=0.90.3',  # min version that allows scipy >= 1.0.0 to be used
-        'pyzmq',  # needed if using tornado < 5
+        'pyzmq',
         'scipy',
         'sympy>=1.4',
-        'tornado'  # needed to avoid errors with older ipykernel
+        'tornado'
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
Since some progress has been made with updating packages I decided to see what happened when all pinnings were removed. The results were encouraging in that issue #210 did not manifest again on Mac in Safari. I played a little and saw only one problem... interacting repeatedly with controller `vector1` in the user manual resulted in the following warning recurring after a while:
```
IOPub message rate exceeded.
The notebook server will temporarily stop sending output
to the client in order to avoid crashing it.
To change this limit, set the config variable
`--NotebookApp.iopub_msg_rate_limit`.

Current values:
NotebookApp.iopub_msg_rate_limit=1000.0 (msgs/sec)
NotebookApp.rate_limit_window=3.0 (secs)
```

@willfurnass could you review, play with these settings, and consider if this is indeed a complete fix? Be good to get @joefresna trying to break it too...

Should close #349 when merged