### PR TITLE
tox.ini: ensure pytest does not bail due to spaces in path to mumot pkg dir not being escaped

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
     jupyter nbextension enable --py --sys-prefix widgetsnbextension
 
     ; Run unit tests and generate code coverage report
-    pytest --verbose --cov-config=tox.ini --cov={envsitepackagesdir}/mumot tests
+    pytest --verbose --cov-config=tox.ini --cov="{envsitepackagesdir}/mumot" tests
 
     ; Ensure the user manual Notebook runs *without errors* (do not check for regressions yet)
     ; (add --nbdime if running tox locally and want to visualise/explore diffs in web browser)
@@ -26,7 +26,7 @@ commands =
 
     ; Ensure test Notebooks runs *without errors* (do not check for regressions yet)
     ; (add --nbdime if running tox locally and want to visualise/explore diffs in web browser)
-    pytest --verbose --maxfail=1 --nbval-lax --cov-config=tox.ini --cov={envsitepackagesdir}/mumot --cov-append \
+    pytest --verbose --maxfail=1 --nbval-lax --cov-config=tox.ini --cov="{envsitepackagesdir}/mumot" --cov-append \
         TestNotebooks/MuMoTtest.ipynb \
         TestNotebooks/MiscTests/MuMoTtest_GreekLetters.ipynb \
         TestNotebooks/MiscTests/MuMoTtest_MultiController.ipynb \
@@ -40,7 +40,7 @@ commands =
 
     ; Ensure the user manual and regression test Notebooks do not show regressions (TODO; leave commented)
     ; (add --nbdime if running tox locally and want to visualise/explore diffs in web browser)
-    ; pytest --verbose --maxfail=1 --nbval --cov-config=tox.ini --cov={envsitepackagesdir}/mumot --cov-append TestNotebooks/MuMoTtest.ipynb
+    ; pytest --verbose --maxfail=1 --nbval --cov-config=tox.ini --cov="{envsitepackagesdir}/mumot" --cov-append TestNotebooks/MuMoTtest.ipynb
 
     ; Check user manual does not contain output cells
     bash -c 'test $(nbshow --outputs docs/MuMoTuserManual.ipynb | wc -c) -eq 0'  


### PR DESCRIPTION
Closes #356