### PR TITLE
Revise release process inc. docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,11 @@ script:
   - tox
   - ls -l .coverage
   - codecov
-  - |
-    if [[ $TRAVIS_TAG ]]; then
-        python3 -m pip install twine
-        python3 setup.py sdist bdist_wheel
-        twine upload dist/mumot-*
-    fi
+  - python3 setup.py sdist bdist_wheel
+deploy:
+  provider: pypi
+  edge: true
+  on:
+    tags: true
+  distributions: "sdist bdist_wheel" 
+  skip_existing: true


### PR DESCRIPTION
 - Travis _shoud_ build and push MuMoT source and binary (wheel) packages to PyPI if the job is triggered by the tagging of a commit rather than a PR (needs testing).
 - Sphinx docs updated to reflect how we've been creating releases to date (by just tagging commit, not by creating dedicated release branches).