### PR TITLE
Unpin versions of ipykernel, notebook, pyzmq and tornado dependencies; add FAQ

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -1,0 +1,12 @@
+FAQ
+===
+
+Why does manipulating widgets create duplicate figures?
+-------------------------------------------------------
+
+Please update your dependencies: versions of the `ipython` dependency older than 7.10.0 are known to cause this problem.
+
+Why are there odd line breaks after inline maths in paragraphs?
+---------------------------------------------------------------
+
+This is a known issue when using Safari; try using Chrome or Firefox instead.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,5 +23,6 @@ MuMoT (Multiscale Modelling Tool) is a tool designed to allow sophisticated math
    getting_started
    install
    about
+   faq
    development
    api

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,17 +30,17 @@ install_requires =
     antlr4-python3-runtime >=4.7,<4.8
     graphviz
     setuptools  # used with Python <3.8 for finding pkg version at runtime (with 3.8 could use importlib.metadata)
-    ipykernel <4.7  # needed so no duplicate figures when wiggle ipywidgets
-    ipython
+    ipykernel
+    ipython >=7.10.0  # minimum required to avoid creating duplicate Figures when changing ipywidget states
     ipywidgets
     matplotlib
     networkx
-    notebook <5.5  # needed if using pyzmq < 17
+    notebook
     pydstool >=0.90.3  # min version that allows scipy >= 1.0.0 to be used
-    pyzmq <17  # needed if using tornado < 5
+    pyzmq
     scipy
     sympy >=1.4,<1.5  # pinned to <1.5 due to Issue #377
-    tornado <5  # needed to avoid errors with older ipykernel
+    tornado
 setup_requres = 
     setuptools_scm
 


### PR DESCRIPTION
Need to do so without resurrecting #158 (duplicate Figures created upon ipywidget state changes).  

The trick here is to set a minimum version of `ipython` (7.10.0).

Also added a FAQ that recommends users update their dependencies if they
encounter the duplicate Figure issue.