### PR TITLE
Prepare for v1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# CHANGELOG
+
+## v1.2.0
+
+Enhancements: 
+
+ - Added more demo notebooks
+ - Support for newer versions of certain Python dependencies (ipykernel, notebook, pyzmq and tornado) 
+ - `realtimePlot` (aka `runtimePlot`) is also available for `multiController`. 
+   However, this is available only when `shareAxes` is `False` or 
+   when the `realtimePlot` is the first view to be plotted. 
+   Other cases cannot be supported at the moment.
+ - Added possibility to use the graphical keywords (`xlab`, `ylab`, `fontsize`, `legend_loc`, `legend_fontsize`, `choose_xrange`, `choose_yrange`) on all commands.
+ - Added analysis to Variance suppression notebook
+
+## v1.1.2
+
+Enhancements:
+
+- Various documentation improvements
+- Added another demo notebook
+- Show id of Figure objects in field views
+- Added possibility to have initial state >1 for `integrate()` and `bifurcation()`
+  For `multiagent()` and `SSA()` the widgets are still limited to the sum of 1
+- Replace `latex2sympy`'s `process_sympy` with `sympy`'s `parse_latex`
+- Update docs to state Python >=3.6 required
+- Refactor MuMoT into separate modules
+  this sets the length of time over which streams are integrated
+- `numPoints` added as keyword to 3D stream plot to set number of streams plotted
+- 3D stream plot now plots streams from random subset of starting points
+- 3D stream plot shading now based on velocity (calculated from line segment length)
+- 1D stream added
+- 3D stream added
+
+Bug fixes:
+
+- Guard against `iopub` rate limiting warnings
+- Increase `nbval` cell exec timeout
+- Suppress `matplotlib` deprecation warning in nested multicontrollers
+- Sum to 1 for all views; implement warnings correctly
+- Patched issue for 1D models
+- Patched issue with multiController
+- Fixed exceptions for stochastic analysis methods
+- Fixed widgets for rates with equation
+- Patched SSA bug
+
+## v1.0.0
+
+- First release

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MuMoT: Multiscale Modelling Tool
 
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/DiODeProject/MuMoT/master?filepath=docs%2FMuMoTuserManual.ipynb)
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.0?filepath=docs%2FMuMoTuserManual.ipynb)
 [![](https://img.shields.io/pypi/v/mumot.svg)](https://pypi.org/pypi/mumot/)
 [![](https://img.shields.io/pypi/pyversions/mumot.svg)](https://pypi.org/pypi/mumot/)
 [![](https://img.shields.io/pypi/l/mumot.svg)](https://pypi.org/pypi/mumot/)

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -28,6 +28,7 @@ Citation
 If you use MuMoT in your own work please cite the original paper describing MuMoT, as well as the DOI for the version of MuMoT you used (to credit developers involved in that version):
 
 * Marshall, J. A. R., Reina, A., Bose, T. (2019) Multiscale Modelling Tool: Mathematical modelling of collective behaviour without the maths. PLoS one **14**(9): e0222906. `doi:10.1371/journal.pone.0222906 <https://doi.org/10.1371/journal.pone.0222906>`__
+* Marshall, J. A. R., Reina, A., Bose, T., Dennison, R., Furnass, W., Pagliara Vasquez, R. (2020) MuMoT release 1.2.0 `10.15131/shef.data.12403118 <https://doi.org/10.15131/shef.data.12403118>`__
 * Marshall, J. A. R., Reina, A., Bose, T., Dennison, R., Furnass, W., Pagliara Vasquez, R. (2019) MuMoT release 1.1.2 `doi:10.15131/shef.data.9925010 <https://doi.org/10.15131/shef.data.9925010>`__
 * Marshall, J. A. R., Reina, A., Bose, T. (2019) MuMoT release 1.0.0 `doi:10.15131/shef.data.7951298.v1 <https://doi.org/10.15131/shef.data.7951298.v1>`__
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -21,7 +21,7 @@ View and interact with the user manual online:
 
 .. image:: https://mybinder.org/badge.svg
    :alt: Start running MuMoT user manual on mybinder.org
-   :target: https://mybinder.org/v2/gh/DiODeProject/MuMoT/master?filepath=docs%2FMuMoTuserManual.ipynb
+   :target: https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.0?filepath=docs%2FMuMoTuserManual.ipynb
 
 Note that this uses the excellent and free `mybinder.org <https://mybinder.org/>`__ service,
 funded by the `Gordon and Betty Moore Foundation <https://www.moore.org/>`__,
@@ -36,12 +36,12 @@ Demo notebooks
 --------------
 The following demo notebooks are also available online:
 
-* `Paper <https://mybinder.org/v2/gh/DiODeProject/MuMoT/master?filepath=docs%2FMuMoTpaperResults.ipynb>`_: (*MuMoT authors, University of Sheffield*)
-* `Epidemics <https://mybinder.org/v2/gh/DiODeProject/MuMoT/master?filepath=DemoNotebooks%2FEpidemicsDemo_SIRI.ipynb>`_: (*Renato Pagliara, Princeton University*)
-* `Agent density <https://mybinder.org/v2/gh/DiODeProject/MuMoT/master?filepath=DemoNotebooks%2FAgent_density.ipynb>`_: (*Yara Khaluf, Ghent University*, and *MuMoT authors, University of Sheffield*)
-* `COVID-19 <https://mybinder.org/v2/gh/DiODeProject/MuMoT/master?filepath=DemoNotebooks%2FCOVID-19.ipynb>`_: (*James A. R. Marshall, University of Sheffield*)
-* `Variance suppression <https://mybinder.org/v2/gh/DiODeProject/MuMoT/master?filepath=DemoNotebooks%2FVariance_suppression.ipynb>`_: (*Andreagiovanni Reina, University of Sheffield*)
-* `Michaelis-Menten <https://mybinder.org/v2/gh/DiODeProject/MuMoT/master?filepath=DemoNotebooks%2FMichaelis-Menten_Dynamics.ipynb>`_: (*Aldo Segura, University of Sheffield*)
+* `Paper <https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.0?filepath=docs%2FMuMoTpaperResults.ipynb>`_: (*MuMoT authors, University of Sheffield*)
+* `Epidemics <https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.0?filepath=DemoNotebooks%2FEpidemicsDemo_SIRI.ipynb>`_: (*Renato Pagliara, Princeton University*)
+* `Agent density <https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.0?filepath=DemoNotebooks%2FAgent_density.ipynb>`_: (*Yara Khaluf, Ghent University*, and *MuMoT authors, University of Sheffield*)
+* `COVID-19 <https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.0?filepath=DemoNotebooks%2FCOVID-19.ipynb>`_: (*James A. R. Marshall, University of Sheffield*)
+* `Variance suppression <https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.0?filepath=DemoNotebooks%2FVariance_suppression.ipynb>`_: (*Andreagiovanni Reina, University of Sheffield*)
+* `Michaelis-Menten <https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.0?filepath=DemoNotebooks%2FMichaelis-Menten_Dynamics.ipynb>`_: (*Aldo Segura, University of Sheffield*)
 
 On your own machine
 -------------------


### PR DESCRIPTION
- Add new version and reserved DOI to citation info in Sphinx docs
- Update mybinder links README.md and Sphinx docs so they reference the `v1.2.0` git ref instead of `master`

AFAICT the only outstanding thing is now creating a `CHANGELOG.md` as per the developer docs.  @jarmarshall Are you happy to do that?