### PR TITLE
Prepare release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v1.2.0
+## v1.2.1
 
 Enhancements: 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MuMoT: Multiscale Modelling Tool
 
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.0?filepath=docs%2FMuMoTuserManual.ipynb)
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.1?filepath=docs%2FMuMoTuserManual.ipynb)
 [![](https://img.shields.io/pypi/v/mumot.svg)](https://pypi.org/pypi/mumot/)
 [![](https://img.shields.io/pypi/pyversions/mumot.svg)](https://pypi.org/pypi/mumot/)
 [![](https://img.shields.io/pypi/l/mumot.svg)](https://pypi.org/pypi/mumot/)

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -28,7 +28,7 @@ Citation
 If you use MuMoT in your own work please cite the original paper describing MuMoT, as well as the DOI for the version of MuMoT you used (to credit developers involved in that version):
 
 * Marshall, J. A. R., Reina, A., Bose, T. (2019) Multiscale Modelling Tool: Mathematical modelling of collective behaviour without the maths. PLoS one **14**(9): e0222906. `doi:10.1371/journal.pone.0222906 <https://doi.org/10.1371/journal.pone.0222906>`__
-* Marshall, J. A. R., Reina, A., Bose, T., Dennison, R., Furnass, W., Pagliara Vasquez, R. (2020) MuMoT release 1.2.0 `10.15131/shef.data.12403118 <https://doi.org/10.15131/shef.data.12403118>`__
+* Marshall, J. A. R., Reina, A., Bose, T., Dennison, R., Furnass, W., Pagliara Vasquez, R. (2020) MuMoT release 1.2.1 `10.15131/shef.data.12403118 <https://doi.org/10.15131/shef.data.12403118>`__
 * Marshall, J. A. R., Reina, A., Bose, T., Dennison, R., Furnass, W., Pagliara Vasquez, R. (2019) MuMoT release 1.1.2 `doi:10.15131/shef.data.9925010 <https://doi.org/10.15131/shef.data.9925010>`__
 * Marshall, J. A. R., Reina, A., Bose, T. (2019) MuMoT release 1.0.0 `doi:10.15131/shef.data.7951298.v1 <https://doi.org/10.15131/shef.data.7951298.v1>`__
 

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -401,7 +401,7 @@ To create a release:
 
    For example: ::
 
-      git archive v1.2.0 | gzip > mumot-v1.2.0.tar.gz
+      git archive v1.2.1 | gzip > mumot-v1.2.1.tar.gz
    
 #. Publish the item in ORDA to ensure:
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -21,7 +21,7 @@ View and interact with the user manual online:
 
 .. image:: https://mybinder.org/badge.svg
    :alt: Start running MuMoT user manual on mybinder.org
-   :target: https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.0?filepath=docs%2FMuMoTuserManual.ipynb
+   :target: https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.1?filepath=docs%2FMuMoTuserManual.ipynb
 
 Note that this uses the excellent and free `mybinder.org <https://mybinder.org/>`__ service,
 funded by the `Gordon and Betty Moore Foundation <https://www.moore.org/>`__,
@@ -36,12 +36,12 @@ Demo notebooks
 --------------
 The following demo notebooks are also available online:
 
-* `Paper <https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.0?filepath=docs%2FMuMoTpaperResults.ipynb>`_: (*MuMoT authors, University of Sheffield*)
-* `Epidemics <https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.0?filepath=DemoNotebooks%2FEpidemicsDemo_SIRI.ipynb>`_: (*Renato Pagliara, Princeton University*)
-* `Agent density <https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.0?filepath=DemoNotebooks%2FAgent_density.ipynb>`_: (*Yara Khaluf, Ghent University*, and *MuMoT authors, University of Sheffield*)
-* `COVID-19 <https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.0?filepath=DemoNotebooks%2FCOVID-19.ipynb>`_: (*James A. R. Marshall, University of Sheffield*)
-* `Variance suppression <https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.0?filepath=DemoNotebooks%2FVariance_suppression.ipynb>`_: (*Andreagiovanni Reina, University of Sheffield*)
-* `Michaelis-Menten <https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.0?filepath=DemoNotebooks%2FMichaelis-Menten_Dynamics.ipynb>`_: (*Aldo Segura, University of Sheffield*)
+* `Paper <https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.1?filepath=docs%2FMuMoTpaperResults.ipynb>`_: (*MuMoT authors, University of Sheffield*)
+* `Epidemics <https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.1?filepath=DemoNotebooks%2FEpidemicsDemo_SIRI.ipynb>`_: (*Renato Pagliara, Princeton University*)
+* `Agent density <https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.1?filepath=DemoNotebooks%2FAgent_density.ipynb>`_: (*Yara Khaluf, Ghent University*, and *MuMoT authors, University of Sheffield*)
+* `COVID-19 <https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.1?filepath=DemoNotebooks%2FCOVID-19.ipynb>`_: (*James A. R. Marshall, University of Sheffield*)
+* `Variance suppression <https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.1?filepath=DemoNotebooks%2FVariance_suppression.ipynb>`_: (*Andreagiovanni Reina, University of Sheffield*)
+* `Michaelis-Menten <https://mybinder.org/v2/gh/DiODeProject/MuMoT/v1.2.1?filepath=DemoNotebooks%2FMichaelis-Menten_Dynamics.ipynb>`_: (*Aldo Segura, University of Sheffield*)
 
 On your own machine
 -------------------


### PR DESCRIPTION
Encountered a problem when releasing v1.2.0 and [PyPI annoyingly does not allow re-using a filename](https://github.com/pypa/packaging-problems/issues/74) so creating v1.2.1.